### PR TITLE
Remove cfg/Makefile and src/Makefile from AC_CONFIG_FILES.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -39,7 +39,5 @@ AC_TYPE_UINT64_T
 
 # Checks for library functions.
 
-AC_CONFIG_FILES([Makefile
-                 cfg/Makefile
-                 src/Makefile])
+AC_CONFIG_FILES([Makefile])
 AC_OUTPUT


### PR DESCRIPTION
Fixes the fallout from change that removed cfg/Makefile.in and
src/Makefile.in.